### PR TITLE
Add 'dry-run' option to check for missing files

### DIFF
--- a/csv2bag
+++ b/csv2bag
@@ -19,7 +19,7 @@ CSV to BagIt
 Consumes a .csv file of collections and converts them into bags.
 
 Usage:
-  #{__FILE__} [--skip] [--map-file=<file>] [--image-file=<file>] [--image-file-path=<dir>] [--console-log-level=<level>] DIR [TARGET]
+  #{__FILE__} [--skip] [--map-file=<file>] [--image-file=<file>] [--image-file-path=<dir>] [--console-log-level=<level>] [--dry-run] DIR [TARGET]
   #{__FILE__} -h | --version
 
 Options:
@@ -30,6 +30,8 @@ Options:
   -v --version                    Show version.
   --image-file=<file>             CSV format file containing mapping from one image file to another in the format old,new
   --image-file-path=<dir>         Path where the full size images are located.
+  --dry-run                       Dry run to check for missing files, no external lookups
+
 
 DOCOPT
 
@@ -239,7 +241,7 @@ def make_coll_bags(dir, target, collection, *args)
   bag_count = graphs.count
 
   if @missing_fields.empty? or @opts['--skip']
-    puts "Making #{bag_count} Bags"
+    @log.info("Making #{bag_count} Bags")
     graphs.each_with_index do |graph, graph_idx|
       subject = ''
       graph.each_statement do |s|
@@ -338,6 +340,43 @@ def move_bags_missing_images(target, collection)
   missing_dirs
 end
 
+
+def dry_run(dir)
+  # Bypass the normal processing and just check if there are missing files.
+  # Checks files mapped by oregon:full
+  Dir.foreach(dir) do |collection|
+    next if collection.start_with?(".")
+    fulls, missing = [], []
+
+    coll_path = File.join(dir, collection)
+    file = File.join(coll_path, "#{collection}.csv")
+    csv_data = CSV.read(file)
+    mapping = csv_data[1]
+    items = csv_data.slice(2, csv_data.count)
+
+    items.each_with_index do |record, record_idx|
+      mapping.each_with_index do |tag, idx|
+        next unless tag == "oregon:full"
+
+        item_full = record[idx]
+        if !item_full.nil? && File.exist?(File.join(coll_path, item_full))
+          fulls << "#{collection}: #{item_full}"
+        else
+          missing << "#{collection}: #{item_full}"
+        end
+      end
+    end
+
+    @log.info("Items: #{items.count}")
+    @log.info("Files Matched: #{fulls.count}")
+    @log.warn("Missing: #{missing.count}") unless missing.empty?
+    missing.each do |m|
+      @log.error("Missing: #{m}")
+    end
+  end
+end
+
+
 begin
   @opts = Docopt::docopt(doc, version: 'csv2bag 0.0.1')
   @folder_id = 1
@@ -369,9 +408,14 @@ begin
   end
   @skip_values = ['unknown', 'n/a']
 
-  make_all_bags(@opts['DIR'], @opts['TARGET'] || 'bags')
-
-  puts @missing_fields unless @missing_fields.empty?
+  if @opts['--dry-run']
+    @log.info("DRY RUN, no external lookups and no bags generated")
+    dry_run(@opts['DIR'])
+  else
+    dry_run(@opts['DIR'])
+    make_all_bags(@opts['DIR'], @opts['TARGET'] || 'bags')
+    puts @missing_fields unless @missing_fields.empty?
+  end
 
 rescue Docopt::Exit => e
   puts e.message


### PR DESCRIPTION
Add 'dry-run' option to check for missing files and display the missing
ones as errors. This will also run by default before each full processing.

Fixes #47 

Sample Output with errors and without:
```
csv2bag feature/dryrun % bundle exec ./csv2bag metadata --skip --console-log-level=info --dry-run
[2017-09-06T13:30:34] INFO  : DRY RUN, no external lookups and no bags generated
[2017-09-06T13:30:36] INFO  : Items: 483
[2017-09-06T13:30:36] INFO  : Files Matched: 482
[2017-09-06T13:30:36] WARN  : Missing: 1
[2017-09-06T13:30:36] ERROR : Missing: microlichens_batch4: 13319Aino HenssenLongSxn3.tif

csv2bag feature/dryrun % bundle exec ./csv2bag metadata --skip --console-log-level=info --dry-run
[2017-09-06T13:30:51] INFO  : DRY RUN, no external lookups and no bags generated
[2017-09-06T13:30:53] INFO  : Items: 483
[2017-09-06T13:30:53] INFO  : Files Matched: 483
```